### PR TITLE
use pip3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip3 install --no-cache --upgrade pip setuptools wheel
 
 COPY ./docker_context/poetry.lock .
 COPY ./docker_context/pyproject.toml .
-RUN pip install poetry==1.1.11
+RUN pip3 install poetry==1.1.11
 RUN poetry config virtualenvs.create false \
   && poetry install --no-interaction --no-ansi
 


### PR DESCRIPTION
The deploy failed with:

```
Step 10/23 : RUN pip install poetry==1.1.11
 ---> Running in d8c3f7e6bccf
/bin/sh: pip: not found
```
but we just used 

```
Step 7/23 : RUN pip3 install --no-cache --upgrade pip setuptools wheel
```

successfully, so let's try using `pip3` instead of `pip`