### PR TITLE
Update poetry to 1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip3 install --no-cache --upgrade pip setuptools wheel
 
 COPY ./docker_context/poetry.lock .
 COPY ./docker_context/pyproject.toml .
-RUN pip3 install poetry==1.1.11
+RUN pip3 install poetry==1.4.2
 RUN poetry config virtualenvs.create false \
   && poetry install --no-interaction --no-ansi
 


### PR DESCRIPTION
There was a `'HTTPResponse' object has no attribute 'strict'` error when building poetry inside the docker container (which only manifested on deploy, or might be a new issue);
https://github.com/python-poetry/poetry/issues/7936 suggests it is an issue with poetry < 1.2 and not pinning urllib to < 3.