### PR TITLE
[FCL-176] Tooling configuration audit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '26 21 * * 1'
+    - cron: "26 21 * * 1"
 
 jobs:
   analyze:
@@ -32,43 +32,42 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language: ["python"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ jobs:
     name: Run local action
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout repository
         uses: actions/checkout@master
       - name: Run latest-tag

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 .env
 __pycache__
+node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,19 +14,7 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.0
     hooks:
-      - id: black
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.0
-    hooks:
-      - id: flake8
-        args: ["--config=setup.cfg"]
-        additional_dependencies: [flake8-isort]
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,9 @@ repos:
     rev: v0.5.0
     hooks:
       - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        types_or: [yaml, json, xml, markdown, scss, javascript]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,18 @@
-exclude: "^docs/|/migrations/"
-default_stages: [commit]
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-xml
       - id: check-yaml
+      - id: end-of-file-fixer
+      - id: forbid-submodules
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
     rev: 24.4.2
@@ -25,9 +30,3 @@ repos:
       - id: flake8
         args: ["--config=setup.cfg"]
         additional_dependencies: [flake8-isort]
-
-# sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
-ci:
-  autoupdate_schedule: weekly
-  skip: []
-  submodules: false

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To deploy to production:
 
 You can republish a PDF by uploading the PDF again, or by sending JSON of the form:
 
+```json
 {
   "Records": [
     {
@@ -40,8 +41,9 @@ You can republish a PDF by uploading the PDF again, or by sending JSON of the fo
         }
       }
     }
- ]
+  ]
 }
+```
 
 to the Send and Receive Messages page of the Simple Queuing System on AWS.
 
@@ -64,11 +66,13 @@ file for you, if you want to remake every PDF that's backed by a docx file.
 Manual integration tests, having run Local Start up tasks above:
 
 You should see output like:
+
 ```
 Downloading judgment.docx
 ...
 Uploaded judgment.pdf
 ```
+
 on startup.
 
 Running `scripts/upload_custom_file.sh` will do nothing, but then `scripts/upload_file.sh` should not upload and display the message:

--- a/aws-config/s3-notify.json
+++ b/aws-config/s3-notify.json
@@ -1,18 +1,18 @@
 {
-    "QueueConfigurations": [
-        {
-            "Events": ["s3:ObjectCreated:*"],
-            "Filter": {
-                "Key": {
-                    "FilterRules": [
-                        {
-                            "Name": "suffix",
-                            "Value": ".docx"
-                        }
-                    ]
-                }
-            },
-            "QueueArn": "arn:aws:sqs:us-east-1:000000000000:pdf-conversion-queue"
+  "QueueConfigurations": [
+    {
+      "Events": ["s3:ObjectCreated:*"],
+      "Filter": {
+        "Key": {
+          "FilterRules": [
+            {
+              "Name": "suffix",
+              "Value": ".docx"
+            }
+          ]
         }
-    ]
+      },
+      "QueueArn": "arn:aws:sqs:us-east-1:000000000000:pdf-conversion-queue"
+    }
+  ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # long lines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
+extend-select = ["W", "B", "Q", "C90", "I", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+                 "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "INT", "PTH",
+                 "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
+unfixable = ["ERA"]
+
+# things skipped:
+# N: naming, possibly good
+# D: docstrings missing throughout
+# ANN: annotations missing throughout
+# FBT: not convinced boolean trap worth auto-banning.
+# CPY: copyright at top of each file
+# G: logging warnings -- fstrings bad?
+# ARG: sometimes you need to accept arguments.
+# TD: somewhat finicky details about formatting TODOs
+# FIX: flags todos: possible to add -- skipped for now
+# ERA: lots of false positives, not a good autofix
+# PD, NPY, AIR: ignored, panda / numpy / airflow specific
+# FURB: not yet out of preview

--- a/queue_listener/queue_listener.py
+++ b/queue_listener/queue_listener.py
@@ -78,15 +78,9 @@ def handle_message(message):
             continue
 
         print(f"Downloading {download_key}")
-        s3_client.download_file(
-            Bucket=bucket_name, Key=download_key, Filename=docx_filename
-        )
+        s3_client.download_file(Bucket=bucket_name, Key=download_key, Filename=docx_filename)
 
-        print(
-            subprocess.run(
-                f"soffice --convert-to pdf {docx_filename} --outdir /tmp".split(" ")
-            )
-        )
+        print(subprocess.run(f"soffice --convert-to pdf {docx_filename} --outdir /tmp".split(" ")))
 
         # NOTE: there's a risk that the local pdf file doesn't exist, we need to handle that case.
         try:
@@ -112,16 +106,12 @@ def handle_message(message):
                 pass
 
     # afterwards:
-    sqs_client.delete_message(
-        QueueUrl=QUEUE_URL, ReceiptHandle=message["ReceiptHandle"]
-    )
+    sqs_client.delete_message(QueueUrl=QUEUE_URL, ReceiptHandle=message["ReceiptHandle"])
 
 
 def poll_once():
     print("Polling...")
-    messages_dict = sqs_client.receive_message(
-        QueueUrl=QUEUE_URL, WaitTimeSeconds=POLL_SECONDS
-    )
+    messages_dict = sqs_client.receive_message(QueueUrl=QUEUE_URL, WaitTimeSeconds=POLL_SECONDS)
     for message in messages_dict.get("Messages", []):
         handle_message(message)
 

--- a/queue_listener/tests.py
+++ b/queue_listener/tests.py
@@ -9,9 +9,7 @@ import queue_listener
 # TRUTHY
 @patch(
     "queue_listener.s3_client.head_object",
-    return_value={
-        "ResponseMetadata": {"HTTPHeaders": {"x-amz-meta-pdfsource": "custom-pdfs"}}
-    },
+    return_value={"ResponseMetadata": {"HTTPHeaders": {"x-amz-meta-pdfsource": "custom-pdfs"}}},
 )
 def test_would_replace_is_custom(head_object):
     """There is a pdfsource, but it is custom-pdfs"""
@@ -22,9 +20,7 @@ def test_would_replace_is_custom(head_object):
 # FALSEY
 @patch(
     "queue_listener.s3_client.head_object",
-    return_value={
-        "ResponseMetadata": {"HTTPHeaders": {"x-amz-meta-pdfsource": "kitten"}}
-    },
+    return_value={"ResponseMetadata": {"HTTPHeaders": {"x-amz-meta-pdfsource": "kitten"}}},
 )
 def test_would_replace_not_custom(head_object):
     """There is a pdfsource, but it isn't custom-pdfs"""
@@ -41,9 +37,7 @@ def test_would_replace_is_empty(head_object):
 
 @patch(
     "queue_listener.s3_client.head_object",
-    side_effect=ClientError(
-        error_response={"Error": {"Message": "Not Found"}}, operation_name=""
-    ),
+    side_effect=ClientError(error_response={"Error": {"Message": "Not Found"}}, operation_name=""),
 )
 def test_would_replace_is_not_found(head_object):
     """There is no such file, so there's nothing to be worried about overwriting"""
@@ -54,9 +48,7 @@ def test_would_replace_is_not_found(head_object):
 # ERRORY
 @patch(
     "queue_listener.s3_client.head_object",
-    side_effect=ClientError(
-        error_response={"Error": {"Message": "Out Of Cheese"}}, operation_name=""
-    ),
+    side_effect=ClientError(error_response={"Error": {"Message": "Out Of Cheese"}}, operation_name=""),
 )
 def test_would_replace_is_bad_response(head_object):
     """An unexpected error occurred, so we re-raise"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,22 +1,3 @@
-[flake8]
-max-line-length = 120
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
-
-[pycodestyle]
-max-line-length = 120
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
-
-[isort]
-line_length = 88
-known_first_party = ds_judgements_public_ui,config
-multi_line_output = 3
-default_section = THIRDPARTY
-skip = venv/
-skip_glob = **/migrations/*.py
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-
 [mypy]
 python_version = 3.9
 check_untyped_defs = True


### PR DESCRIPTION
A series of commits which together make all of FCL's repositories behave more consistently with regard to tooling.

## Jira

FCL-176

## What?

- [x] `.pre-commit-config.yaml` does not exclude directories which don't exist, doesn't set default hooks where they aren't needed, and doesn't specify auto-update behaviour
- [x] The `pre-commit-hooks` repo includes the new, broader set of recommended checks
- [x] Python formatting is done using [ruff](https://docs.astral.sh/ruff/)
- [x] `detect-secrets` is removed (deprecated in favour of GitHub's more comprehensive approach)
- [x] prettier config has been harmonised