### PR TITLE
Use upstream latest-tag because dxw fork is outdated and archived

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@master
       - name: Run latest-tag
-        uses: dxw/latest-tag@force-branch
+        uses: EndBug/latest-tag@force-branch
         with:
           tag-name: production
           force-branch: true


### PR DESCRIPTION
Recommend leaving this until we understand PDF Conversion deployment better.

Before:

<img width="1108" alt="image" src="https://github.com/user-attachments/assets/717c73ee-c15e-460a-82c4-fab02c416675">
