### PR TITLE
Font fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,14 @@ COPY ./queue_listener ./queue_listener
 COPY ./docker_context .
 COPY ./fonts ./fonts
 
+ENV HOME=/
+
 # Copy a LibreOffice config file which uses Times New Roman as the
 # default font -- see README.txt
-RUN mkdir -p /root/.config/libreoffice/4/user
-RUN mkdir /root/.config/fontconfig
-RUN cp registrymodifications.xcu /root/.config/libreoffice/4/user/registrymodifications.xcu
-RUN cp fonts.conf /root/.config/fontconfig/fonts.conf
+RUN mkdir -p $HOME/.config/libreoffice/4/user
+RUN mkdir $HOME/.config/fontconfig
+RUN cp registrymodifications.xcu $HOME/.config/libreoffice/4/user/registrymodifications.xcu
+RUN cp fonts.conf $HOME/.config/fontconfig/fonts.conf
 
 # Install fonts
 RUN mkdir -p /usr/share/fonts/truetype/docker-context

--- a/README.md
+++ b/README.md
@@ -85,3 +85,9 @@ on startup.
 `upload_custom_pdf` will upload a tagged PDF, which should cause `upload_file` to fail with `judgment.pdf is from custom-pdfs, not replacing`
 
 `upload_named_pdf` will upload a docx of your choosing
+
+### Verifying font fallback in place
+
+The output of `fc-match gibberish` should be something like
+
+> `Times_New_Roman.ttf: "Times New Roman" "Regular"`


### PR DESCRIPTION
Font fallback to Times New Roman failed, presumably because updating the base image moved the root user's home to `/`, not `/root`.