### PR TITLE
Fix Dockerfile building by specifying package-mode false in the pyproject.toml

### DIFF
--- a/docker_context/pyproject.toml
+++ b/docker_context/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.poetry]
 name = "libreoffice-with-msfonts"
+package-mode = false
 version = "0.1.0"
 description = ""
 authors = ["Laura Porter <laura@dxw.com>"]


### PR DESCRIPTION
Fix Dockerfile building by specifying package-mode false in the pyproject.toml

Verified fixed locally.

(followup PR coming to build the image in CI, to prevent only catching this at deploy time in future!)


Fixes:

```
Installing the current project: libreoffice-with-msfonts (0.1.0)

Error: The current project could not be installed: No file/folder found for package libreoffice-with-msfonts
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
If you did intend to install the current project, you may need to set packages in your pyproject.toml file.

The command '/bin/sh -c /etc/poetry/bin/poetry config virtualenvs.create false && /etc/poetry/bin/poetry install --no-interaction --no-ansi' returned a non-zero code: 1

[Container] 2025/07/07 09:19:55.957666 Command did not exit successfully docker build -t $IMAGE_REPO_NAME:test . exit status 1
[Container] 2025/07/07 09:19:55.963097 Phase complete: PRE_BUILD State: FAILED
[Container] 2025/07/07 09:19:55.963113 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: docker build -t $IMAGE_REPO_NAME:test .. Reason: exit status 1
```