### PR TITLE
Allow wider variety of python versions

### DIFF
--- a/docker_context/poetry.lock
+++ b/docker_context/poetry.lock
@@ -2,18 +2,18 @@
 
 [[package]]
 name = "boto3"
-version = "1.42.96"
+version = "1.42.92"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "boto3-1.42.96-py3-none-any.whl", hash = "sha256:2f4566da2c209a98bdbfc874d813ef231c84ad24e4f815e9bc91de5f63351a24"},
-    {file = "boto3-1.42.96.tar.gz", hash = "sha256:b38a9e4a3fbbee9017252576f1379780d0a5814768676c08df2f539d31fcdd68"},
+    {file = "boto3-1.42.92-py3-none-any.whl", hash = "sha256:c90d9a170faa0585755fa103a3cd9595e1f53443864e902c180f3d8177589125"},
+    {file = "boto3-1.42.92.tar.gz", hash = "sha256:55ec6ef6fc81f46d567a7d1d398d1e5c375d468905d0ccd9e1f767f0c77dbe9b"},
 ]
 
 [package.dependencies]
-botocore = ">=1.42.96,<1.43.0"
+botocore = ">=1.42.92,<1.43.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.16.0,<0.17.0"
 
@@ -22,14 +22,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.42.96"
+version = "1.42.97"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "botocore-1.42.96-py3-none-any.whl", hash = "sha256:db2c3e2006628be6fde81a24124a6563c363d6982fb92728837cf174bad9d98a"},
-    {file = "botocore-1.42.96.tar.gz", hash = "sha256:75b3b841ffacaa944f645196655a21ca777591dd8911e732bfb6614545af0250"},
+    {file = "botocore-1.42.97-py3-none-any.whl", hash = "sha256:77d2c8ce1bc592d3fbd7c01c35836f4a5b0cac2ca03ccdf6ffc60faa16b5fadc"},
+    {file = "botocore-1.42.97.tar.gz", hash = "sha256:5c0bb00e32d16ff6d278cc8c9e10dc3672d9c1d569031635ac3c908a60de8310"},
 ]
 
 [package.dependencies]
@@ -900,5 +900,5 @@ test = ["pytest", "pytest-cov"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "==3.14.4"
-content-hash = "2707c94a4f4bb6e93aa5ae28bd08be4cd13b50f52d71c0ec51b996cff231ef84"
+python-versions = ">3.12"
+content-hash = "33750bdfe3d030fe8bfe5c7aca70d97fdcff6a632be56f6b2e386a9bd3970b38"

--- a/docker_context/poetry.lock
+++ b/docker_context/poetry.lock
@@ -2,18 +2,18 @@
 
 [[package]]
 name = "boto3"
-version = "1.42.92"
+version = "1.42.96"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "boto3-1.42.92-py3-none-any.whl", hash = "sha256:c90d9a170faa0585755fa103a3cd9595e1f53443864e902c180f3d8177589125"},
-    {file = "boto3-1.42.92.tar.gz", hash = "sha256:55ec6ef6fc81f46d567a7d1d398d1e5c375d468905d0ccd9e1f767f0c77dbe9b"},
+    {file = "boto3-1.42.96-py3-none-any.whl", hash = "sha256:2f4566da2c209a98bdbfc874d813ef231c84ad24e4f815e9bc91de5f63351a24"},
+    {file = "boto3-1.42.96.tar.gz", hash = "sha256:b38a9e4a3fbbee9017252576f1379780d0a5814768676c08df2f539d31fcdd68"},
 ]
 
 [package.dependencies]
-botocore = ">=1.42.92,<1.43.0"
+botocore = ">=1.42.96,<1.43.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.16.0,<0.17.0"
 
@@ -901,4 +901,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.12"
-content-hash = "33750bdfe3d030fe8bfe5c7aca70d97fdcff6a632be56f6b2e386a9bd3970b38"
+content-hash = "140da26d71d9926361ba59aee3b927477eda4c3b23768ef03262631cea31d81d"

--- a/docker_context/pyproject.toml
+++ b/docker_context/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Laura Porter <laura@dxw.com>"]
 
 [tool.poetry.dependencies]
 python = ">3.12"
-boto3 = "1.42.92"
+boto3 = "1.42.96"
 python-dotenv = "1.2.2"
 rollbar = "1.3.0"
 urllib3 = "==2.6.3"

--- a/docker_context/pyproject.toml
+++ b/docker_context/pyproject.toml
@@ -6,8 +6,8 @@ description = ""
 authors = ["Laura Porter <laura@dxw.com>"]
 
 [tool.poetry.dependencies]
-python = "==3.14.4"
-boto3 = "1.42.96"
+python = ">3.12"
+boto3 = "1.42.92"
 python-dotenv = "1.2.2"
 rollbar = "1.3.0"
 urllib3 = "==2.6.3"


### PR DESCRIPTION
CI appears to be trying to use Python 3.12.12, so pinning to 3.14 fails.