### PR TITLE
Update expat apk to have correct version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN apk add -u libffi libffi-dev build-base gcc python3-dev curl
 
 # Install python/poetry
 ENV PYTHONUNBUFFERED=1
-RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 - || cat /poetry-installer-error-*
+RUN curl -sSL https://install.python-poetry.org -o /tmp/poetry-installer.py && \
+    POETRY_HOME=/etc/poetry python3 /tmp/poetry-installer.py || \
+    { cat /poetry-installer-error-*; exit 1; }
 COPY ./docker_context/poetry.lock .
 COPY ./docker_context/pyproject.toml .
 RUN /etc/poetry/bin/poetry config virtualenvs.create false

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM lscr.io/linuxserver/libreoffice:7.6.7@sha256:125e1bcf0a055cc9e5983a421fe7ec
 RUN apk --no-cache add msttcorefonts-installer fontconfig && \
     update-ms-fonts && \
     fc-cache -f
-RUN apk add libffi libffi-dev build-base gcc python3-dev curl
+RUN apk add -u libffi libffi-dev build-base gcc python3-dev curl
 
 # Install python/poetry
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCLC-1791

https://gitlab.alpinelinux.org/alpine/aports/-/issues/16441

This seems to fix the issue locally.

```
File "/usr/lib/python3.12/xml/parsers/expat.py", line 4, in <module>
    from pyexpat import *
ImportError: Error relocating /usr/lib/python3.12/lib-dynload/pyexpat.cpython-312-x86_64-linux-musl.so: XML_SetAllocTrackerActivationThreshold: symbol not found
```