### PR TITLE
Ensure docker doesn't expose ports externally

### DIFF
--- a/docker-compose-localstack.yml
+++ b/docker-compose-localstack.yml
@@ -8,7 +8,8 @@ services:
       SERVICES: sns,s3,sqs
       DEBUG: 0
     ports:
-      - 4566:4566
+      - "127.0.0.1:4566:4566"
+      - "[::1]:4566:4566"
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
https://docs.docker.com/engine/network/port-publishing/

> Publishing container ports is insecure by default. Meaning, when you publish a container's ports it becomes available not only to the Docker host, but to the outside world as well.
> If you include the localhost IP address (127.0.0.1, or ::1) with the publish flag, only the Docker host can access the published container port.
> `docker run -p 127.0.0.1:8080:80 -p '[::1]:8080:80' nginx`

A similar warning exists for [ports](https://docs.docker.com/reference/compose-file/services/#ports)
