### PR TITLE
Use ENTRYPOINT to start the queue listener container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN mkdir -p /usr/share/fonts/truetype/docker-context
 RUN find /fonts/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/docker-context/ \; || return 1
 RUN fc-cache -f && rm -rf /var/cache/*
 
-CMD ["python", "queue_listener/queue_listener.py"]
+ENTRYPOINT ["python", "queue_listener/queue_listener.py"]

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -19,7 +19,7 @@ function run_docker() {
             docker build -t pdf-conversion:${tag} .
         fi
     fi
-    docker run --rm --user root pdf-conversion:${tag} /etc/poetry/bin/poetry run pytest queue_listener/ -vvvv
+    docker run --rm --user root --entrypoint /etc/poetry/bin/poetry pdf-conversion:${tag} run pytest queue_listener/ -vvvv
 }
 
 case "$1" in


### PR DESCRIPTION
Switch the container startup to ENTRYPOINT so the queue listener is launched directly when the container starts, with runtime environment variables available at execution time. This makes the Docker startup behavior more predictable and avoids relying on CMD for process startup.

FCLC-1791